### PR TITLE
Removed `ssl on;` setting

### DIFF
--- a/example.com.conf
+++ b/example.com.conf
@@ -28,7 +28,6 @@ server {
     #
     # listen 443 ssl http2;
     # listen [::]:443 ssl http2;
-    # ssl on;
     # ssl_certificate /etc/nginx/ssl/example.com.crt;
     # ssl_certificate_key /etc/nginx/ssl/example.com.key;
 


### PR DESCRIPTION
The `ssl on;` setting is no longer available. We can remove it.

[https://nginx.org/en/docs/http/configuring_https_servers.html](https://nginx.org/en/docs/http/configuring_https_servers.html)